### PR TITLE
Update retrieve pattern, otherwise you can get java.lang.RuntimeException

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
     <property name="ivy.version" value="2.2.0"/>
 
     <target name="fetch-jars" depends="install-ivy">
-        <ivy:retrieve pattern="lib/[artifact]-[revision].[ext]" symlink="true"/>
+        <ivy:retrieve pattern="lib/[conf]/[artifact]-[type]-[revision].[ext]" symlink="true"/>
     </target>
 
     <target name="install-ivy">


### PR DESCRIPTION
Update retrieve pattern, otherwise you can get java.lang.RuntimeException: Multiple artifacts of the module org.mockito#mockito-all;1.8.4 are retrieved to the same file! Update the retrieve pattern  to fix this error.
    at org.apache.ivy.core.retrieve.RetrieveEngine.retrieve(RetrieveEngine.java:206)

when have dependencies like: <dependency org="org.mockito" name="mockito-all" rev="1.8.4"/>
